### PR TITLE
Add componentWillUnmount to clearTimeout

### DIFF
--- a/src/web/index.js
+++ b/src/web/index.js
@@ -61,7 +61,7 @@ export default class ShimmerImage extends Component<Props, State> {
      * However, given delay should be not more than 1 second. If it is just ignore it.
      */
     if (delay && delay > 0 && delay <= 1000) {
-      setTimeout(() => {
+      this.timeout = setTimeout(() => {
         if (!this.state.src) {
           this.setState({ isLoading: true })
         }
@@ -76,6 +76,10 @@ export default class ShimmerImage extends Component<Props, State> {
     } catch (error) {
       this.setState({ error, isLoading: false })
     }
+  }
+
+  componentWillUnmount(){
+    clearTimeout(this.timeout);
   }
 
   loadImage = async (uri: string) => {


### PR DESCRIPTION
I'm pretty new to contributions so please bear with me. I noticed that when you navigate to a different URL (I am using `react-router-dom`)  before the Shimmer Image resolves, the library is trying to `setState` the unmounted Shimmer Image component. I suggest adding a `clearTimeout` when the `componentWillUnmount` to resolve these kinds of error:

<img width="768" alt="screen shot 2018-09-05 at 2 42 49 pm" src="https://user-images.githubusercontent.com/13685868/45123140-c3614d00-b11a-11e8-8ae2-8ecb737424fb.png">
