### PR TITLE
web: Correctly validate presence of width/height

### DIFF
--- a/src/web/index.js
+++ b/src/web/index.js
@@ -76,7 +76,7 @@ export default class ShimmerImage extends React.Component<Props, State> {
 
   startImageLoadingProcess = async () => {
     const { src, delay, width, height, fallback } = this.props
-    if (!fallback && !(width & height)) {
+    if (!fallback && !(width && height)) {
       this.setState({ error: 'Height and Width props must be provided!' })
     }
     /*


### PR DESCRIPTION
Currently, this check performs a bitwise check when width and height
properties are provided.

This commit uses an `&&` which will validate that both properties are not
"empty" values (null, undefined, 0 ...).

(This is the first frontend javascript PR I've made in a very long time, so
I'm not too sure how to write a regression test for this. If you need
one and have any guidance that would be :+1:)